### PR TITLE
concurrently running front and backend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ You can install dependencies by `npm install` in your Frontend and after that yo
 
 ### `npm start`
 
-Runs the app in the development mode.\
+Runs only Frontend in the development mode.\
+You can enter `npm start` in the base directory.\
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+Runs only Backend in the development mode.\
+You can go to Back by `cd api` and enter `npm start`.\
+Open [http://localhost:5000](http://localhost:5000) to view it in the browser.
+
+Runs Backend as well as Frontend in the development mode.\
+You can enter `npm run dev` in the base directory.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
 The page will reload if you make edits.\

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-react": "^7.12.7",
+    "concurrently": "^6.0.2",
     "parcel-plugin-static-files-copy": "^2.5.0"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "api": "npm start --prefix api",
+    "dev": "concurrently \"npm run start\" \"npm run api\""
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
This might not be in the top of things to do but I think since we are running backend and frontend at the same time why not to do that with single  npm script? I have added concurrently package for this purpose and now you can run both backend and frontend with single script `npm run dev` at base directory. 